### PR TITLE
Update AmbrosialEncrypt.cs (silly edition)

### DIFF
--- a/Ambrosial/Classes/AmbrosialEncrypt.cs
+++ b/Ambrosial/Classes/AmbrosialEncrypt.cs
@@ -1,47 +1,36 @@
-﻿using Microsoft.VisualBasic;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Ambrosial.Ambrosial.Classes
 {
     public static class AmbrosialEncrypt
     {
-        private static string alphaChars;
-        private static string GenerateRandomString(int length)
+        private static readonly string alphaChars = @"!#$%&*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{}~";
+
+        public static string GenerateRandomString(int length)
         {
-            alphaChars = @"!#$%&*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{}~";
-            VBMath.Randomize();
-            string temp = "";
-            checked
+            var random = new Random();
+            var sb = new StringBuilder(length);
+            for (int i = 0; i < length; i++)
             {
-                for (int x = 0; x <= length; x++)
-                {
-                    int i = (int)Math.Round(Math.Floor((double)(unchecked((float)(checked(alphaChars.Length - 1 + 1)) * VBMath.Rnd())))) + 1;
-                    temp += Strings.Mid(alphaChars, i, 1);
-                }
-                return temp;
+                sb.Append(alphaChars[random.Next(alphaChars.Length)]);
             }
+            return sb.ToString();
         }
 
         public static string Encrypt(string inputString)
         {
-            string input = inputString;
-            string rand = GenerateRandomString(15);
-            input = Cipher.Encrypt(input, rand);
-            input += "[AmbrosialPacket]" + rand;
-            return Cipher.EncryptBase64(input);
+            var rand = GenerateRandomString(15);
+            var encrypted = Cipher.Encrypt(inputString, rand);
+            return encrypted + "[AmbrosialPacket]" + rand;
         }
 
         public static string Decrypt(string inputString)
         {
-            string input = inputString;
-            string decryptedBasePacket = Cipher.DecryptBase64(input);
-            string[] packInfo = decryptedBasePacket.Split(new string[] { "[AmbrosialPacket]" }, StringSplitOptions.RemoveEmptyEntries);
+            var decryptedBasePacket = Cipher.DecryptBase64(inputString);
+            var packInfo = decryptedBasePacket.Split(new[] { "[AmbrosialPacket]" }, StringSplitOptions.RemoveEmptyEntries);
             return Cipher.Decrypt(packInfo[0], packInfo[1]);
         }
-
     }
 }
+


### PR DESCRIPTION
iceayy contribution attempt #1

removed alphaChars var ssince it was declared as private static, but never used outside of the GenerateRandomString method.. so we get rid of it!!! no more!! we hate!!!!!!!!!

removed checked keyword from GenerateRandomString method. it WAS used to make sure that integer arithmetic operations dont overflow, but this simply does not lol because the min value of the int is larger than the length of the alphachars string

replaced the strings.mid method with the char indexy thingamabooby. was uused to extract a single char from a string, buuuut we simplify by using the char indexer so it can be used to access a single char at a specific index in a string.

my c# skills are so silly
make sure to like and subscribe for more silly pull requests on the silliest website half of all programs rely on to not die randomly.